### PR TITLE
aws config support for hazelcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This cookbook installs OrientDB
 Requirements
 ------------
 
-It has been tested on Ubuntu 12.04, but should work on any platform where Java 1.6 works. 
+It has been tested on Ubuntu 12.04, but should work on any platform where Java 1.6 works.
 
-The java and apt cookbooks are needed, as usual may be handled with Berkshelf. 
+The java and apt cookbooks are needed, as usual may be handled with Berkshelf.
 
 
 General Attributes:
@@ -34,11 +34,19 @@ Distributed Attributes:
 |`node['orientdb']['hazelcast']['enabled']`|Enable Hazelcast plugin|`true`|
 |`node['orientdb']['hazelcast']['group']['name']`|Hazelcast group name|`orientdb`|
 |`node['orientdb']['hazelcast']['group']['password']`|Hazelcast group password|`orientdb`|
-|`node['orientdb']['hazelcast']['network']['join']['multicast']['enabled']`|Enable Hazelcast multicast|`orientdb`|
+|`node['orientdb']['hazelcast']['network']['join']['mode']`|Hazelcast mode, one of `multicast`, `tcp-ip` or `aws`|`multicast`|
 |`node['orientdb']['hazelcast']['network']['join']['multicast']['group']`|Hazelcast multicast host|`orientdb`|
 |`node['orientdb']['hazelcast']['network']['join']['multicast']['port']`|Hazelcast multicast port|`orientdb`|
 |`node['orientdb']['node_search_criteria']`|Chef Search criteria for locating peers.|Match on hazelcast group name & password (from above)|
 |`node['orientdb']['hazelcast']['network']['join']['tcp-ip']['members']`|Array of hostname:port of peer hazelcast members to populate hazelcast.xml file.|hostname:port list from node_search_criteria (above)|
+|`node['orientdb']['hazelcast']['network']['join']['aws']['access-key']`|EC2 access key|`my-access-key`|
+|`node['orientdb']['hazelcast']['network']['join']['aws']['secret-key']`|EC2 secret key|`my-secret-key`|
+|`node['orientdb']['hazelcast']['network']['join']['aws']['region']`|Optional, EC2 region|`us-west-1`|
+|`node['orientdb']['hazelcast']['network']['join']['aws']['host-header']`|Optional, EC2 host header. If set region shouldn't be set as it will override this property|`ec2.amazonaws.com`|
+|`node['orientdb']['hazelcast']['network']['join']['aws']['security-group-name']`|EC2 security group|`hazelcast-sg`|
+|`node['orientdb']['hazelcast']['network']['join']['aws']['tag-key']`|EC2 tag key|`type`|
+|`node['orientdb']['hazelcast']['network']['join']['aws']['tag-value']`|EC2 tag value|`hz-nodes`|
+
 |`node['orientdb']['distributed']['clusters']['servers']`|Array of hostnames to populate default-distributed-db-config.json file.|hostname list from node_search_criteria (above)|
 
 
@@ -79,4 +87,3 @@ License and Authors
 MIT License
 
 Authors: Federico Gimenez Nieto <fgimenez@coit.es>
-

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,9 +18,19 @@ default['orientdb']['hazelcast']['enabled'] = true
 default['orientdb']['hazelcast']['group']['name'] = 'orientdb'
 default['orientdb']['hazelcast']['group']['password'] = 'orientdb'
 default['orientdb']['hazelcast']['network']['port'] = '2434'
-default['orientdb']['hazelcast']['network']['join']['multicast']['enabled'] = true
+
+default['orientbd']['hazelcast']['network']['join']['mode'] = 'multicast'
 default['orientdb']['hazelcast']['network']['join']['multicast']['group'] = '235.1.1.1'
 default['orientdb']['hazelcast']['network']['join']['multicast']['port'] = '2434'
+
+default['orientdb']['hazelcast']['network']['join']['aws']['access-key'] = 'my-access-key'
+default['orientdb']['hazelcast']['network']['join']['aws']['secret-key'] = 'my-secret-key'
+default['orientdb']['hazelcast']['network']['join']['aws']['region'] = 'us-west-1'
+default['orientdb']['hazelcast']['network']['join']['aws']['host-header'] = 'ec2.amazonaws.com'
+default['orientdb']['hazelcast']['network']['join']['aws']['security-group-name'] = 'hazelcast-sg'
+default['orientdb']['hazelcast']['network']['join']['aws']['tag-key'] = 'type'
+default['orientdb']['hazelcast']['network']['join']['aws']['tag-value'] = 'hz-nodes'
+
 
 default['orientdb']['node_search_criteria'] = "orientdb_hazelcast_group_name:#{node['orientdb']['hazelcast']['group']['name']} AND orientdb_hazelcast_group_password:#{node['orientdb']['hazelcast']['group']['password']}"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fgimenez@coit.es'
 license          'Apache-2.0'
 description      'Installs/Configures OrientDB'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.0'
+version          '0.5.0'
 
 %w[ubuntu debian].each do |os|
   supports os

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -8,23 +8,97 @@ describe 'orientdb::configuration' do
   end
 
   describe 'configuration files' do
-    it 'creates default-distributed-db-config.json' do
-      expect(runner).to create_template("#{$installation_directory}/config/default-distributed-db-config.json").with(
-        owner: $user_id,
-        group: $user_id
+    ['default-distributed-db-config.json',
+     'hazelcast.xml',
+     'orientdb-server-config.xml'].each do |config_file|
+      it "creates #{config_file}" do
+        expect(runner).to create_template(
+                            "#{$installation_directory}/config/#{config_file}").with(
+                            owner: $user_id,
+                            group: $user_id
       )
+      end
     end
-    it 'creates hazelcast.xml' do
-      expect(runner).to create_template("#{$installation_directory}/config/hazelcast.xml").with(
-        owner: $user_id,
-        group: $user_id
-      )
-    end
-    it 'creates orientdb-server-config.xml' do
-      expect(runner).to create_template("#{$installation_directory}/config/orientdb-server-config.xml").with(
-        owner: $user_id,
-        group: $user_id
-      )
+  end
+
+  describe 'template contents' do
+    context 'hazelcast' do
+      let(:chef_run) { ChefSpec::SoloRunner.new }
+      let(:file) { File.join($installation_directory, 'config', 'hazelcast.xml') }
+      context 'multicast enabled' do
+        before do
+          chef_run.node.set['orientdb']['installation_directory'] = $installation_directory
+          chef_run.node.set['orientdb']['hazelcast']['network']['join']['mode'] ='multicast'
+          chef_run.node.set['orientdb']['hazelcast']['network']['join']['multicast']['group'] ='my_multicast_group'
+          chef_run.node.set['orientdb']['hazelcast']['network']['join']['multicast']['port'] ='my_multicast_port'
+          chef_run.converge(described_recipe)
+        end
+
+        it 'shows multicast enabled' do
+          expect(chef_run).to render_file(file).with_content(/^\s*<multicast enabled="true">$/)
+        end
+
+        ['group', 'port'].each do |attr|
+          it "shows multicast #{attr}" do
+            expect(chef_run).to render_file(file).with_content(
+                                  /^\s*<multicast-#{attr}>my_multicast_#{attr}<\/multicast-#{attr}>$/)
+          end
+        end
+
+        ['tcp-ip', 'aws'].each do |mode|
+          it "does not show #{mode} config" do
+            expect(chef_run).not_to render_file(file).with_content(/^\s*<#{mode} .*>/)
+          end
+        end
+      end
+
+      context 'tcp-ip enabled' do
+        before do
+          chef_run.node.set['orientdb']['installation_directory'] = $installation_directory
+          chef_run.node.set['orientdb']['hazelcast']['network']['join']['mode'] ='tcp-ip'
+          chef_run.node.set['orientdb']['hazelcast']['network']['join']['tcp-ip']['members'] = ['member1', 'member2']
+          chef_run.converge(described_recipe)
+        end
+
+        it 'shows multicast disabled' do
+          expect(chef_run).to render_file(file).with_content(/^\s*<multicast enabled="false">$/)
+        end
+
+        it 'shows tcp-ip enabled' do
+          expect(chef_run).to render_file(file).with_content(/^\s*<tcp-ip enabled="true">$/)
+        end
+
+        it 'shows the members' do
+          expect(chef_run).to render_file(file).with_content(/^\s*<member>member1<\/member><member>member2<\/member>$/)
+        end
+      end
+
+      context 'amazon ec2 enabled' do
+        before do
+          chef_run.node.set['orientdb']['installation_directory'] = $installation_directory
+          chef_run.node.set['orientdb']['hazelcast']['network']['join']['mode'] ='aws'
+          ['access-key', 'secret-key', 'region', 'host-header', 'security-group-name',
+         'tag-key', 'tag-value'].each do |attr|
+            chef_run.node.set['orientdb']['hazelcast']['network']['join']['aws'][attr] = "my_aws_#{attr}"
+          end
+          chef_run.converge(described_recipe)
+        end
+
+        it 'shows multicast disabled' do
+          expect(chef_run).to render_file(file).with_content(/^\s*<multicast enabled="false">$/)
+        end
+
+        it 'shows aws enabled' do
+          expect(chef_run).to render_file(file).with_content(/^\s*<aws enabled="true">$/)
+        end
+
+        ['access-key', 'secret-key', 'region', 'host-header', 'security-group-name',
+         'tag-key', 'tag-value'].each do |attr|
+          it "shows #{attr}" do
+            expect(chef_run).to render_file(file).with_content(/^\s*<#{attr}>my_aws_#{attr}<\/#{attr}>$/)
+          end
+        end
+      end
     end
   end
 end

--- a/templates/default/hazelcast.xml.erb
+++ b/templates/default/hazelcast.xml.erb
@@ -5,13 +5,13 @@
 # Do NOT modify this file directly.
 #
 -->
-<!-- ~ Copyright (c) 2008-2012, Hazel Bilisim Ltd. All Rights Reserved. ~ 
-	~ Licensed under the Apache License, Version 2.0 (the "License"); ~ you may 
-	not use this file except in compliance with the License. ~ You may obtain 
-	a copy of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ 
-	~ Unless required by applicable law or agreed to in writing, software ~ distributed 
-	under the License is distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES 
-	OR CONDITIONS OF ANY KIND, either express or implied. ~ See the License for 
+<!-- ~ Copyright (c) 2008-2012, Hazel Bilisim Ltd. All Rights Reserved. ~
+	~ Licensed under the Apache License, Version 2.0 (the "License"); ~ you may
+	not use this file except in compliance with the License. ~ You may obtain
+	a copy of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~
+	~ Unless required by applicable law or agreed to in writing, software ~ distributed
+	under the License is distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES
+	OR CONDITIONS OF ANY KIND, either express or implied. ~ See the License for
 	the specific language governing permissions and ~ limitations under the License. -->
 
 <hazelcast
@@ -24,14 +24,26 @@
 	<network>
 		<port auto-increment="true"><%= node['orientdb']['hazelcast']['network']['port']%></port>
 		<join>
-			<multicast enabled="<%= node['orientdb']['hazelcast']['network']['join']['multicast']['enabled']%>">
+<% if node['orientdb']['hazelcast']['network']['join']['mode'] == 'multicast'%>
+			<multicast enabled="true">
+<% else %>
+      <multicast enabled="false">
+<% end -%>
 				<multicast-group><%= node['orientdb']['hazelcast']['network']['join']['multicast']['group']%></multicast-group>
 				<multicast-port><%= node['orientdb']['hazelcast']['network']['join']['multicast']['port']%></multicast-port>
 			</multicast>
-<% if !node['orientdb']['hazelcast']['network']['join']['multicast']['enabled'] -%>
+<% case node['orientdb']['hazelcast']['network']['join']['mode'] %>
+<% when 'tcp-ip' %>
 			<tcp-ip enabled="true">
 				<member><%= node['orientdb']['hazelcast']['network']['join']['tcp-ip']['members'].join('</member><member>') %></member>
 			</tcp-ip>
+<% when 'aws' %>
+			<aws enabled="true">
+  <% ['access-key', 'secret-key', 'region', 'host-header', 'security-group-name',
+         'tag-key', 'tag-value'].each do |attr| %>
+        <<%=attr%>><%=node['orientdb']['hazelcast']['network']['join']['aws'][attr]%></<%=attr%>>
+  <% end %>
+			</aws>
 <% end -%>
 		</join>
 	</network>


### PR DESCRIPTION
Related to #14, adds support for AWS in distributed mode according to http://orientdb.com/docs/2.0/orientdb.wiki/Distributed-Configuration.html#amazon-ec2

@mdbelt , can you review the changes, please?
